### PR TITLE
Remove duplicate "Trip-hop" genre

### DIFF
--- a/beetsplug/lastgenre/genres.txt
+++ b/beetsplug/lastgenre/genres.txt
@@ -1459,7 +1459,6 @@ tribal house
 trikitixa
 trip hop
 trip rock
-trip-hop
 tropicalia
 tropicalismo
 tropipop


### PR DESCRIPTION
## Description

Remove "Trip-hop" because it's duplicate (the other one is "Trip hop").
For more information see https://github.com/beetbox/beets/discussions/4503#discussioncomment-3781639

(...)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
